### PR TITLE
Update p5 CDN to use latest minified minor version

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width">
     <title>repl.it</title>
     <link href="style.css" rel="stylesheet" type="text/css" />
-    <script src="https://cdn.jsdelivr.net/npm/p5@1.3.1/lib/p5.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/p5@1.4/lib/p5.min.js"></script>
   </head>
   <body>
     <script src="script.js"></script>


### PR DESCRIPTION
We could use the latest major version 1.x.x but we don't want to worry about anything breaking. 1.4.x will be good enough for now.

Also, let's use the `.min.js` version since the non minified version of 1.4.1 is 4.12MB while the minified version is 803.88 KB. Major difference for load time.

https://cdn.jsdelivr.net/npm/p5@1.4.1/lib/